### PR TITLE
Add AP attributes

### DIFF
--- a/tasks/lib/normalizeResults.js
+++ b/tasks/lib/normalizeResults.js
@@ -26,6 +26,7 @@ var translation = {
     seat: "seatName",
     description: "description",
     flippedSeat: "flippedSeat",
+    winThreshold: "winThreshold",
   },
   unit: {
     level: "level",


### PR DESCRIPTION
I specified a few additional data attributes from the AP feed to be passed through to our generated datafiles:

* `winnerTimestamp`
* `flippedSeat`
* `winThreshold`

To verify, run `grunt --APtest` and check the generated datafile for `build/data/states/FL.json`.

* `winnerTimestamp` should appear at the candidate level for races with a call.
* `flippedSeat` will appear at the race level
* `winThreshold` will not always appear, but if it does, it will most likely be with ballot initiatives (FL has a 60% threshold to win)