### PR TITLE
Represent independent winners according to how they caucus (closes #196)

### DIFF
--- a/project.json
+++ b/project.json
@@ -20,7 +20,8 @@
   "scripts": {
     "src/js/main.js": "build/app.js",
     "src/js/loadHeaderBidding.js": "build/loadHeaderBidding.js",
-    "src/js/state.js": "build/state.js"
+    "src/js/state.js": "build/state.js",
+    "src/js/embedBOP.js": "build/embedBOP.js"
   },
   "scriptsOnce": {
     "src/js/embed.js": "build/embed.js",

--- a/project.json
+++ b/project.json
@@ -14,7 +14,8 @@
     "src/css/senate.less": "build/senate.css",
     "src/css/state.less": "build/state.css",
     "src/css/house.less": "build/house.css",
-    "src/css/county.less": "build/county.css"
+    "src/css/county.less": "build/county.css",
+    "src/css/embeds.less": "build/embeds.css"
   },
   "scripts": {
     "src/js/main.js": "build/app.js",
@@ -31,9 +32,9 @@
   "url": "https://apps.npr.org/2024-election-results/",
   "image": "assets/logo.png",
   "analytics": {
-    "topicIDs": [],
-    "primaryTopic": "",
-    "secondaryTopics": []
+    "topicIDs": [1014,139482413,1088064557,1197733670],
+    "primaryTopic": "elections",
+    "secondaryTopics": ["p139482413",1014]
   },
   "sheets": [ 
     "1zlv0MndWsdLnp15NI1tFjD7eJuvcYgpmhutASiOqcgk",

--- a/src/css/embeds.less
+++ b/src/css/embeds.less
@@ -6,10 +6,6 @@ h1 {
     font-size: 24px;
 }
 
-#mcmullin_note {
-    margin: 0px;
-}
-
 #nav-list {
     width: 100%;
 
@@ -481,6 +477,10 @@ main.embed-bop {
         display: block;
     }
 
+    .bop-footer {
+      position: relative;
+    }
+
     .number-container {
         display: flex;
         justify-content: center;
@@ -587,13 +587,10 @@ main.embed-bop {
 
             &.other {
                 background: @ind;
-                float: left;
 
-                path {
-                    fill: @ind;
-                }
+                path { fill: @ind; }
             }
-        }
+          }
 
         // .label {
         //   display: none;
@@ -677,6 +674,13 @@ main.embed-bop {
 
     .source {
         margin-top: 55px;
+    }
+
+    .footnote {
+      font-size: 11px;
+      font-style: italic;
+      color: #999;
+      margin-top: 5px;
     }
 }
 
@@ -1193,11 +1197,13 @@ main.embed-homepage {
 
             &.other {
                 background: @ind;
-                float: left;
 
                 path {
                     fill: @ind;
                 }
+
+                // &.dem { float: left; }
+                // &.gop { float: right; }
             }
         }
 

--- a/src/embeds/bop.html
+++ b/src/embeds/bop.html
@@ -1,0 +1,28 @@
+<%
+var metadata = {
+  project: Object.assign({}, grunt.data.json.project, {
+    title: "Election 2024: Balance of power in Congress (embed)",
+    description: "",
+    embedded: true
+  })
+};
+%>
+
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <%= t.include("partials/_head.html", metadata) %>
+    <link rel="stylesheet" type="text/css" href="../style.css">
+  </head>
+  <body>
+
+    <board-combined></board-combined>
+
+    <script>
+      window.PROJECT_ANALYTICS = <%= JSON.stringify(json.project.analytics || {}) %>;
+    </script>
+    <script src="../embedBOP.js" async></script>
+
+    <%= t.include("partials/_analytics.html") %>
+  </body>
+</html>

--- a/src/js/components/balance-of-power-combined/index.js
+++ b/src/js/components/balance-of-power-combined/index.js
@@ -39,6 +39,7 @@ class BalanceOfPowerCombined extends ElementBase {
 
             this.senate = this.data.senate;
             this.house = this.data.house;
+
             this.render();
         } catch (error) {
             console.error("Could not load JSON data:", error);

--- a/src/js/components/balance-of-power-senate/index.js
+++ b/src/js/components/balance-of-power-senate/index.js
@@ -43,6 +43,9 @@ class BalanceOfPowerSenate extends ElementBase {
     render() {
         if (!this.data) return;
 
+        console.log('balance-of-power-senate', this.data);
+
+        //! UPDATE THIS — WE SHOULD NOT BE HARD-CODING THIS
         var InactiveSenateRaces = {
             "GOP": 38,
             "Dem": 28,
@@ -54,12 +57,15 @@ class BalanceOfPowerSenate extends ElementBase {
 
         var results = (this.data.results);
 
-        var mcmullinWon = false;
+        var showUnaffiliated = false;
 
         var senate = {
             Dem: { total: InactiveSenateRaces.Dem, gains: 0 },
             GOP: { total: InactiveSenateRaces.GOP, gains: 0 },
             Ind: { total: InactiveSenateRaces.Other, gains: 0 },
+            IndCaucusDem: { total: 0, gains: 0 },
+            IndCaucusGOP: { total: 0, gains: 0 },
+            IndUnaffiliated: { total: 0, gains: 0 },
             Other: { total: (0), gains: 0  },
             Con: { total: (0), gains: 0  },
             Lib: { total: (0), gains: 0  }
@@ -67,31 +73,47 @@ class BalanceOfPowerSenate extends ElementBase {
 
         results.forEach(function (r) {
           if (r.hasOwnProperty('called') && r.called == true) {
-            if (r.id == '46329' && r.winnerParty == 'Ind') {
-              mcmullinWon = true;
-            }
-        
             var winnerParty = r.winnerParty;
+            if (winnerParty != "Dem" && winnerParty != "GOP") {
+              winnerParty = "Ind";
+            }
+
             var previousWinner = r.previousParty;
-        
+            var caucusWith = r.caucusWith;
+
             if (!senate[winnerParty]) {
               senate[winnerParty] = { total: 0, gains: 0 };
             }
             if (!senate[previousWinner]) {
               senate[previousWinner] = { total: 0, gains: 0 };
             }
-        
+
             senate[winnerParty].total += 1;
             if (winnerParty != previousWinner) {
               senate[winnerParty].gains += 1;
               senate[previousWinner].gains -= 1;
             }
+
+            // account for how an independent candidate may caucus
+            if (winnerParty == "Ind") {
+              if (r.caucusWith && r.caucusWith == "GOP") {
+                senate.IndCaucusGOP.total += 1;
+              }
+              if (r.caucusWith && r.caucusWith == "Dem") {
+                senate.IndCaucusDem.total += 1;
+              }
+              if (!r.caucusWith) {
+                senate.IndUnaffiliated.total += 1;
+                showUnaffiliated = true;
+              }
+            }
+        
           }
         });
-
-        senate.Ind.width = senate.Ind.total;
-        if (mcmullinWon) {
-            senate.Ind.width = (senate.Ind.total) - 1;
+        
+        var footnote = "";
+        if (showUnaffiliated) {
+          footnote = `<div class="footnote">* Independents who caucus with Democrats (${ senate.IndCaucusDem.total }) or Republicans (${ senate.IndCaucusGOP.total }) are shown in the bar chart. Unaffiliated independents (${ senate.IndUnaffiliated.total }) are not shown in the chart but are included in the overall count.</div>`
         }
 
         senate.netGainParty = "none";
@@ -116,7 +138,7 @@ class BalanceOfPowerSenate extends ElementBase {
         ${senate.Ind.total ?
                 `<div class="candidate other">
             <div class="name">Ind. ${senate.Ind.total >= 51 ? winnerIcon : ""}</div>
-            <div class="votes">${senate.Ind.total}${mcmullinWon ? "*" : ""}</div>
+            <div class="votes">${senate.Ind.total}${showUnaffiliated ? "*" : ""}</div>
           </div>`
                 : ""}
         ${100 - senate.Dem.total - senate.GOP.total - senate.Ind.width ?
@@ -134,21 +156,27 @@ class BalanceOfPowerSenate extends ElementBase {
  <div class="bar-container">
   <div class="bar dem" style="width: ${senate.Dem.total}%">
   </div>
-  <div class="bar other" style="width: ${senate.Ind.width}%">
+  <div class="bar other dem" style="width: ${senate.IndCaucusDem.total}%">
   </div>
   <div class="bar gop" style="width: ${senate.GOP.total}%">
+  </div>
+  <div class="bar other gop" style="width: ${senate.IndCaucusGOP.total}%">
   </div>
   <div class="middle"></div>
 </div>
       </div>
 
-      <div class="chatter"><strong>51</strong> seats for majority</div>
+      <div class="bop-footer">
+        <div class="chatter"><strong>51</strong> seats for majority</div>
 
-      <div class="net-gain-container">
-        <div class="net-gain ${senate.netGainParty}">${senate.netGainParty != "none"
-                ? `${senate.netGainParty} +${senate.netGain}`
-                : "No change"}</div>
+        <div class="net-gain-container">
+          <div class="net-gain ${senate.netGainParty}">${senate.netGainParty != "none"
+                  ? `${senate.netGainParty} +${senate.netGain}`
+                  : "No change"}</div>
+        </div>
       </div>
+
+      ${ footnote }
     </a>
   </div>
   `;

--- a/src/js/components/balance-of-power-senate/index.js
+++ b/src/js/components/balance-of-power-senate/index.js
@@ -126,6 +126,8 @@ class BalanceOfPowerSenate extends ElementBase {
             senate.netGain = topSenate.gains;
         }
 
+
+        //! UPDATE OR REMOVE LINK (LINK IS ONLY NEEDED FOR EMBED)
         this.innerHTML = `
       <main class="embed-bop">
     <div id="embed-bop-on-page" class="embed-bop">
@@ -141,7 +143,7 @@ class BalanceOfPowerSenate extends ElementBase {
             <div class="votes">${senate.Ind.total}${showUnaffiliated ? "*" : ""}</div>
           </div>`
                 : ""}
-        ${100 - senate.Dem.total - senate.GOP.total - senate.Ind.width ?
+        ${100 - senate.Dem.total - senate.GOP.total - senate.Ind.total ?
                 `<div class="candidate uncalled">
             <div class="name">Not yet called</div>
             <div class="votes">${100 - senate.Dem.total - senate.GOP.total - senate.Ind.total}</div>

--- a/src/js/embedBOP.js
+++ b/src/js/embedBOP.js
@@ -1,0 +1,17 @@
+var Sidechain = require("@nprapps/sidechain");
+
+require("./analytics");
+var BalanceOfPowerCombined = require("./components/balance-of-power-combined");
+// require("./components/balance-of-power-bar");
+
+// look for URL params
+var search = new URLSearchParams(window.location.search);
+var params = {
+  president: null,
+  inline: null,
+  theme: null,
+  hideCongress: null,
+  onlyPresident: null
+};
+for (var k in params) params[k] = search.get(k);
+

--- a/tasks/elex.js
+++ b/tasks/elex.js
@@ -154,6 +154,7 @@ module.exports = function (grunt) {
         winner: r.winnerParty,
         electoral: r.electoral,
         previous: r.previousParty,
+        caucusWith: r.caucusWith
       };
     };
 

--- a/tasks/lib/normalizeResults.js
+++ b/tasks/lib/normalizeResults.js
@@ -51,6 +51,7 @@ const translation = {
     incumbent: "incumbent",
     rankedChoiceVotes: "rankedChoiceVotes",
     eliminated: "eliminated",
+    caucusWith: "caucusWith"
   },
   metadata: {
     previousParty: "party",
@@ -303,6 +304,10 @@ module.exports = function (resultArray, overrides = {}) {
         if (winner) {
           unitMeta.called = true;
           unitMeta.winnerParty = winner.party;
+
+          if (winner.caucusWith) {
+            unitMeta.caucusWith = winner.caucusWith;
+          }
         }
 
         unitMeta.candidates = ballot;


### PR DESCRIPTION
I've set things up according to the following rules:
* Independents who caucus with Dems are added to a yellow bar attached to the end of the Dem bar
* Independents who caucus with Reps are added to a yellow bar attached to the end of the GOP bar (new)
* Unaffiliated independents are included in the overall count of independents, but are not represented in the bar. Instead, a footnote appears explaining what's going on. (This was basically our "McMullin scenario" in the 2022 code.)

<img width="510" alt="image" src="https://github.com/user-attachments/assets/3cdfa095-df38-4963-9673-87d8f00bffc1">

For testing: The `20241009` test data includes 2 dem-aligned independents and 1 unaffiliated independent. And then I edited the AP data (in `temp/`) for the AK House results to test an independent winner in that race (moving the winner flags to that candidate).

I also started a BOP embed (`src/embeds/bop.html`) to test how this played out using the `balance-of-power-combined` component. Got the overall page working, but the component itself was not loading in. Committing what I have for now.