### PR TITLE
update house and gov board sort

### DIFF
--- a/src/js/components/results-board-display/index.js
+++ b/src/js/components/results-board-display/index.js
@@ -110,6 +110,7 @@ class ResultsBoardDisplay extends ElementBase {
     render() {
         //if (!this.senate || !this.house) return;
 
+        var thisOffice = this.office.toLowerCase();
         var { results, test, latest, alert } = this.state;
         this.state.results = this.results
 
@@ -130,8 +131,8 @@ class ResultsBoardDisplay extends ElementBase {
             };
 
             sorted.forEach(function (r) {
-                var bucketRating = getBucket(r.rating);
-                if (bucketRating) buckets[bucketRating].push(r);
+              var bucketRating = getBucket(r.rating, thisOffice);
+              if (bucketRating) buckets[bucketRating].push(r);
             });
         }
 
@@ -170,19 +171,19 @@ class ResultsBoardDisplay extends ElementBase {
             ${this.results ? `
                 <results-board 
                     office="House"
-                    hed="Likely/Solid Democratic"
+                    hed="Lean Democratic"
                     class="first"
                     races='${JSON.stringify(buckets.likelyD || []).replace(/'/g, "&#39;")}'>
                 </results-board>
                 <results-board 
                     office="House"
-                    hed="Likely/Solid Democratic"
+                    hed="Toss-Up Seats"
                     class="middle"
                     races='${JSON.stringify(buckets.tossup || []).replace(/'/g, "&#39;")}'>
                 </results-board>
                 <results-board 
                     office="House"
-                    hed="Likely/Solid Republican"
+                    hed="Lean Republican"
                     class="last"
                     races='${JSON.stringify(buckets.likelyR || []).replace(/'/g, "&#39;")}'>
                 </results-board>
@@ -192,13 +193,25 @@ class ResultsBoardDisplay extends ElementBase {
         } else if (this.office.includes('governor')) {
             content += `
                 <div class="board-container Gov">
-                    ${this.results ? `
+                      ${this.results ? `
+                        <results-board 
+                            office="Governor"
+                            hed="Likely/Solid Democratic"
+                            class="first"
+                            races='${JSON.stringify(buckets.likelyD)}'>
+                        </results-board>
                         <results-board 
                             office="Governor"
                             split="true"
                             hed="Competitive Seats"
                             class="middle"
-                            races='${JSON.stringify(sorted)}'>
+                            races='${JSON.stringify(buckets.tossup)}'>
+                        </results-board>
+                        <results-board 
+                            office="Governor"
+                            hed="Likely/Solid Republican"
+                            class="last"
+                            races='${JSON.stringify(buckets.likelyR)}'>
                         </results-board>
                     ` : ''}
                 </div>

--- a/src/js/components/util.js
+++ b/src/js/components/util.js
@@ -107,13 +107,27 @@ function getPartyPrefix(party) {
   return prefix;
 }
 
-function getBucket(rating) {
-  if (rating == "solid-d" || rating == "likely-d") {
-    return "likelyD";
-  } else if (rating == "lean-d" || rating == "toss-up" || rating == "lean-r") {
-    return "tossup";
-  } else if (rating == "solid-r" || rating == "likely-r") {
-    return "likelyR";
+function getBucket(rating, chamber = null) {
+  if (chamber == "house") {
+    if (rating == "lean-d" || rating == "solid-d" || rating == "likely-d") {
+      return "likelyD";
+    } else if (rating == "toss-up") {
+      return "tossup";
+    } else if (rating == "solid-r" || rating == "likely-r" || rating == "lean-r") {
+      return "likelyR";
+    } else {
+      console.log("bucket error", rating);
+    }
+  } else {
+    if (rating == "solid-d" || rating == "likely-d") {
+      return "likelyD";
+    } else if (rating == "lean-d" || rating == "toss-up" || rating == "lean-r") {
+      return "tossup";
+    } else if (rating == "solid-r" || rating == "likely-r") {
+      return "likelyR";
+    } else {
+      console.log("bucket error", rating);
+    }
   }
 }
 


### PR DESCRIPTION
Changes:
* Update column headers for the House board
* Change the sort for House races to show only toss-ups in the middle
* Sort Gov board by ratings

/cc @juweek for visibility