### PR TITLE
add to race result footnotes

### DIFF
--- a/src/js/components/results-table/_results-table.html
+++ b/src/js/components/results-table/_results-table.html
@@ -11,5 +11,6 @@
 	<p class="footnote" data-as="footnoteMetadata">AP estimate: <span data-as="eevp"></span> &bull; Last updated: <span data-as="updated"></span>. <span data-as="callTimestamp"></span></p>
 	<p class="footnote" data-as="uncontestedFootnote">The AP does not tabulate votes for uncontested races and declares their winners as soon as polls close.</p>
 	<p class="footnote" data-as="rcvFootnote"></p>
+	<p class="footnote" data-as="winThresholdFootnote"></p>
 	<p class="footnote" data-as="specialElectionFootnote"></p>
 </div>

--- a/src/js/components/results-table/_results-table.html
+++ b/src/js/components/results-table/_results-table.html
@@ -8,7 +8,7 @@
 	</div>
 	<div class="tbody" data-as="tbody"></div>
 	<p class="footnote incumbent-legend" data-as="incumbentLegend"><span class="incumbent-dot">•</span> Incumbent</p>
-	<p class="footnote">AP estimate: <span data-as="eevp"></span>. Last updated <span data-as="updated"></span>.</p>
+	<p class="footnote" data-as="footnoteMetadata">AP estimate: <span data-as="eevp"></span> &bull; Last updated: <span data-as="updated"></span>. <span data-as="callTimestamp"></span></p>
 	<p class="footnote" data-as="uncontestedFootnote">The AP does not tabulate votes for uncontested races and declares their winners as soon as polls close.</p>
 	<p class="footnote" data-as="rcvFootnote"></p>
 	<p class="footnote" data-as="specialElectionFootnote"></p>

--- a/src/js/components/results-table/index.js
+++ b/src/js/components/results-table/index.js
@@ -40,6 +40,20 @@ class ResultsTable extends ElementBase {
     elements.updated.innerHTML = `${formatAPDate(new Date(result.updated))} at ${formatTime(new Date(result.updated))}`;
     elements.eevp.innerHTML = formatEEVP(result.eevp);
 
+    var diff = (new Date(result.updated) - new Date(result.candidates[0].winnerDateTime)) / 1000;
+    if (diff > 0) {
+      console.log(`${ result.state }-${ result.office }: ${ diff } seconds difference`);
+      console.log("result.updated", new Date(result.updated));
+      console.log("winnerDateTime", new Date(result.candidates[0].winnerDateTime));
+    }
+
+    if (result.candidates[0].winner === "X" && result.candidates[0].winnerDateTime) {
+      var winnerDateTime = result.candidates[0].winnerDateTime;
+      elements.callTimestamp.innerHTML = ` &bull; Winner called: ${formatAPDate(new Date(winnerDateTime))} at ${formatTime(new Date(winnerDateTime))}.`;
+    } else {
+      elements.callTimestamp.innerHTML.remove();
+    }
+
     if (result.office === "P") {
       elements.wrapper.classList.add("president");
     }
@@ -65,6 +79,8 @@ class ResultsTable extends ElementBase {
 
     if (candidates.length > 1) {
       elements.uncontestedFootnote.remove();
+    } else {
+      elements.footnoteMetadata.remove();
     }
 
     if (result.flags) {

--- a/src/js/components/results-table/index.js
+++ b/src/js/components/results-table/index.js
@@ -80,7 +80,6 @@ class ResultsTable extends ElementBase {
     if (candidates.length > 1) {
       elements.uncontestedFootnote.remove();
     } else {
-      elements.footnoteMetadata.remove();
     }
 
     if (result.flags) {
@@ -100,6 +99,13 @@ class ResultsTable extends ElementBase {
       }
     } else {
       elements.rcvFootnote.remove();
+    }
+
+    // show winThreshold for ballot measures where the threshold isn't a simple majority
+    if (result.office == "I" && result.winThreshold && result.winThreshold != 50) {
+      elements.winThresholdFootnote.innerHTML = `This measure must win at least ${ result.winThreshold }% of the vote to pass.`
+    } else {
+      elements.winThresholdFootnote.remove();
     }
 
     if (candidates.some(d => d[0].incumbent) === true) {

--- a/src/js/components/results-table/index.js
+++ b/src/js/components/results-table/index.js
@@ -80,6 +80,7 @@ class ResultsTable extends ElementBase {
     if (candidates.length > 1) {
       elements.uncontestedFootnote.remove();
     } else {
+      elements.footnoteMetadata.style.display = "none";
     }
 
     if (result.flags) {

--- a/src/js/components/results-table/index.js
+++ b/src/js/components/results-table/index.js
@@ -51,7 +51,7 @@ class ResultsTable extends ElementBase {
       var winnerDateTime = result.candidates[0].winnerDateTime;
       elements.callTimestamp.innerHTML = ` &bull; Winner called: ${formatAPDate(new Date(winnerDateTime))} at ${formatTime(new Date(winnerDateTime))}.`;
     } else {
-      elements.callTimestamp.innerHTML.remove();
+      elements.callTimestamp.remove();
     }
 
     if (result.office === "P") {


### PR DESCRIPTION
Changes:
* Hide timestamps and other metadata from uncontested results
* Note winThresholds (mainly for FL ballot initiatives) #69 
* Add call times #30 