### PR TITLE
build loading screen for result pages/hide 'undefined' text on render  

### DIFF
--- a/project.json
+++ b/project.json
@@ -22,6 +22,7 @@
   "scripts": {
     "src/js/main.js": "build/app.js",
     "src/js/loadHeaderBidding.js": "build/loadHeaderBidding.js",
+    "src/js/removeLoadingScreen.js": "build/removeLoadingScreen.js",
     "src/js/state.js": "build/state.js",
     "src/js/customizer.js": "build/customizer.js",
     "src/js/raceEmbed.js": "build/raceEmbed.js",

--- a/src/bop.html
+++ b/src/bop.html
@@ -37,6 +37,7 @@
         // Run when page loads
         window.addEventListener('DOMContentLoaded', buildComponents);
       </script>
+    <script class="remove-loading" src="removeLoadingScreen.js" async></script>
     <script src="app.js" async></script>
     <%= t.include("partials/_analytics.html") %>
   </body>

--- a/src/css/loading-screen.less
+++ b/src/css/loading-screen.less
@@ -1,18 +1,19 @@
 
 
-#loadingScreenContainer {
+#page-loadingScreen-container {
     position: relative;
     width: 100%;
     height: 100%;
 }
 
-#loadingScreen {
+#page-loadingScreen {
     position: absolute;
     width: 100%;
     height: 100%;
     min-height: 100vh;
     width: 100vw;
     background-color: #fff;
-    opacity: .9;
+    opacity: .92;
     z-index: 99;
+    pointer-events: none;
 }

--- a/src/governors.html
+++ b/src/governors.html
@@ -44,6 +44,7 @@ var metadata = {
     <%= t.include("partials/_analytics.html") %>
     <%= t.include("partials/_sponsorship.html", { "production": grunt.data.json.project.production }) %>
     <script class="remove-embedded" src="loadHeaderBidding.js" async></script>
+    <script class="remove-loading" src="removeLoadingScreen.js" async></script>
     <script>
       var here = new URL(window.location);
     

--- a/src/house.html
+++ b/src/house.html
@@ -44,6 +44,7 @@ var metadata = {
     <%= t.include("partials/_analytics.html") %>
     <%= t.include("partials/_sponsorship.html", { "production": grunt.data.json.project.production }) %>
     <script class="remove-embedded" src="loadHeaderBidding.js" async></script>
+    <script class="remove-loading" src="removeLoadingScreen.js" async></script>
     <script>
       var here = new URL(window.location);
     

--- a/src/index.html
+++ b/src/index.html
@@ -42,6 +42,7 @@ var metadata = {
     <%= t.include("partials/_sponsorship.html", { "production": json.project.production }) %>
     <%= t.include("partials/_analytics.html") %>
     <script class="remove-embedded" src="loadHeaderBidding.js" async></script>
+    <script class="remove-loading" src="removeLoadingScreen.js" async></script>
     <script>
       var here = new URL(window.location);
     

--- a/src/js/components/board-senate/index.js
+++ b/src/js/components/board-senate/index.js
@@ -22,7 +22,6 @@ class BoardSenate extends ElementBase {
         super();
         this.state = {};
         this.results = []
-        //this.onData = this.onData.bind(this);
         this.loadData = this.loadData.bind(this);
     }
 
@@ -51,7 +50,13 @@ class BoardSenate extends ElementBase {
             this.render();
           } catch (error) {
             console.error('Error fetching senate data:', error);
-          }
+            // Optionally show error state
+            this.innerHTML = `
+                <div class="error-message">
+                    Error loading Senate results. Please try again later.
+                </div>
+            `;
+        }
     }
 
     /**

--- a/src/js/removeLoadingScreen.js
+++ b/src/js/removeLoadingScreen.js
@@ -1,0 +1,167 @@
+const boardTypes = {
+    'board-president': ['board-president', 'results-board-display'],
+    'board-senate': ['balance-of-power-senate', 'results-board-display'],
+    'board-house': ['balance-of-power-house', 'results-board-display'],
+    'board-governor': ['results-board-display']
+};
+
+(function () {
+    const CHECK_INTERVAL = 100;
+    const MAX_WAIT_TIME = 25000; //25 seconds
+    let checkCount = 0;
+    let successiveReadyChecks = 0;
+    const REQUIRED_SUCCESSIVE_CHECKS = 2;
+    const startTime = Date.now();
+
+    /**
+     * Functions to create and remove a loading screen overlay into the main content area. 
+     * To create, we first look for main.app.constrained, then the loading screen is inserted as the first child of the main element. 
+     * the main content's position is set to relative for proper overlay positioning.
+     * 
+     * @returns {void}
+     */
+    function createLoadingScreen() {
+        const mainContent = document.querySelector('main.app.constrained');
+        if (!mainContent) return;
+
+        const loadingScreen = document.createElement('div');
+        loadingScreen.id = 'page-loadingScreen';
+        mainContent.style.position = 'relative';
+        mainContent.insertBefore(loadingScreen, mainContent.firstChild);
+    }
+
+    function removeLoadingScreen() {
+        const loadingScreen = document.getElementById('page-loadingScreen');
+        if (loadingScreen) {
+            loadingScreen.style.opacity = '0';
+            loadingScreen.style.transition = 'opacity 0.1s ease-out';
+
+            setTimeout(() => {
+                loadingScreen.remove();
+                // Reset main's position if needed
+            }, 50);
+        } else {
+            console.log('Loading screen element not found');
+        }
+    }
+
+    /**
+     * Determines which selectors should be checked based on the page content.
+     * Checks for either BOP embed wrapper or specific board types (president, senate, house, governor).
+     * 
+     * @returns {string[]} Array of html elements that need to be checked to see if they're rendered 
+     */
+    function determineRequiredSelectors() {
+        const bopWrapper = document.getElementById('bop-embed-wrapper');
+        if (bopWrapper) return ['bop-embed-wrapper', 'bop-wrapper'];
+
+        return Object.entries(boardTypes)
+            .filter(([selector]) => document.querySelector(selector))
+            .flatMap(([boardType, selectors]) => [boardType, ...selectors]);
+    };
+
+
+    /**
+     * Checks to see  all required elements are properly rendered and visible on the page.
+     * 
+     * The function handles three types of selectors:
+     * 1. board-* selectors: Checked directly at document level
+     * 2. bop-* selectors: Searched by ID
+     * 3. Child elements: Searched within their board parent context
+     * 
+     * @returns {boolean} Returns true if all required content is ready and rendered,
+     *                    false if any required element is missing or not properly rendered
+     */
+    function isContentReady() {
+        const requiredSelectors = determineRequiredSelectors();
+
+        return requiredSelectors.every(selector => {
+            // Get the target element based on selector type
+            const element = (() => {
+                if (selector.startsWith('board-')) {
+                    return document.querySelector(selector);
+                }
+
+                if (selector.includes('bop-')) {
+                    return document.getElementById(selector);
+                }
+
+                // For child elements, find within board parent
+                const boardParent = document.querySelector(
+                    Object.keys(boardTypes).find(board =>
+                        document.querySelector(board)
+                    )
+                );
+                return boardParent?.querySelector(selector);
+            })();
+
+            // Check if element exists and is properly rendered
+            if (!element?.innerHTML?.trim()) {
+                return false;
+            }
+
+            const style = window.getComputedStyle(element);
+            const rect = element.getBoundingClientRect();
+
+            return !(
+                style.display === 'none' ||
+                style.visibility === 'hidden' ||
+                rect.width === 0 ||
+                rect.height === 0
+            );
+        });
+    }
+
+    /**
+     * Uses a successive check system to ensure content stability before removal.
+     * Will force remove the loading screen if maximum wait time is exceeded.
+     * 
+     * 
+     * @requires REQUIRED_SUCCESSIVE_CHECKS - Number of successful checks needed
+     * @requires MAX_WAIT_TIME - Maximum milliseconds to wait. after its done, hide the loading screen regardless
+     * @requires CHECK_INTERVAL - Milliseconds between checks 
+     */
+    function checkAndRemoveLoadingScreen() {
+        checkCount++;
+
+        if (isContentReady()) {
+            successiveReadyChecks++;
+            if (successiveReadyChecks >= REQUIRED_SUCCESSIVE_CHECKS) {
+                removeLoadingScreen();
+                return;
+            }
+        } else {
+            // Reset the counter if any check fails
+            if (successiveReadyChecks > 0) {
+                successiveReadyChecks = 0;
+            }
+        }
+
+        // Check if we've exceeded maximum wait time
+        if (Date.now() - startTime > MAX_WAIT_TIME) {
+            console.warn('Loading screen timeout: removing after maximum wait time');
+            removeLoadingScreen();
+            return;
+        }
+
+        // Continue checking
+        requestAnimationFrame(() => {
+            setTimeout(checkAndRemoveLoadingScreen, CHECK_INTERVAL);
+        });
+    }
+
+    /**
+     * Initialize the loading screen system based on document ready state
+     * Handles both cases where DOM is still loading or already complete
+     */
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => {
+            console.log('DOMContentLoaded fired, starting checks...');
+            createLoadingScreen();
+            checkAndRemoveLoadingScreen();
+        });
+    } else {
+        createLoadingScreen();
+        checkAndRemoveLoadingScreen();
+    }
+})();

--- a/src/presidentMaps.html
+++ b/src/presidentMaps.html
@@ -41,6 +41,7 @@
         // Run when page loads
         window.addEventListener('DOMContentLoaded', buildComponents);
     </script>
+    <script class="remove-loading" src="removeLoadingScreen.js" async></script>
     <script src="app.js" async></script>
     <%= t.include("partials/_analytics.html") %>
 </body>

--- a/src/senate.html
+++ b/src/senate.html
@@ -23,9 +23,7 @@ var metadata = {
     <%= t.include("partials/_ad.html", {id: "ad-centerstage"}) %>
     <%= t.include("partials/_about-box.html") %>
     <main class="app constrained">
-
       <board-senate></board-senate>
-
       <p class="footnote page-footnote">
         <strong>Notes:</strong>
         <%= t.smarty(grunt.data.json.strings.eevp_footnote) %>
@@ -44,6 +42,7 @@ var metadata = {
     <%= t.include("partials/_analytics.html") %>
     <%= t.include("partials/_sponsorship.html", { "production": grunt.data.json.project.production }) %>
     <script class="remove-embedded" src="loadHeaderBidding.js" async></script>
+    <script class="remove-loading" src="removeLoadingScreen.js" async></script>
     <script>
       var here = new URL(window.location);
     


### PR DESCRIPTION
- implemented the loading screen for the big boards (notes below)
- hides the 'undefined' text that appears as some components wait to load

---------

wrote a script called `removeLoadingScreen.js`that takes the current page, puts a loading screen over it, and continually checks a list of rendered elements to see if they exist. if they do, the light screen goes down. if they don't, the light screen remains up

note: i did preliminary testing on mid-tier and low-tier connections on chrome device testing, and this solution has not yet been optimized for those devices