### PR TITLE
Update link targets

### DIFF
--- a/src/bop.html
+++ b/src/bop.html
@@ -4,7 +4,7 @@
     <%= t.include("partials/_head.html", grunt.data.json) %>
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" type="text/css" href="customizer.css">
-
+    <base target="_blank">
   </head>
   <body>
 

--- a/src/js/components/balance-of-power-house/index.js
+++ b/src/js/components/balance-of-power-house/index.js
@@ -112,10 +112,8 @@ class BalanceOfPowerHouse extends ElementBase {
       house.netGain = topHouse.gains;
     }
 
-    //! UPDATE OR REMOVE LINK (LINK IS ONLY NEEDED FOR EMBED)
     this.innerHTML = `
     <div id="embed-bop-on-page">
-      <a class="link-container house" href="/house.html" target="_top">
         <div class="number-container">
           <div class="candidate dem">
             <div class="name">Dem. ${house.Dem.total >= 218 ? winnerIcon : ""}</div>
@@ -151,9 +149,8 @@ class BalanceOfPowerHouse extends ElementBase {
           <div class="chatter"><strong>218</strong> seats for majority</div>
         </div>
 
-      ${ footnote }
+        ${ footnote }
       </div>
-      </a>
     </div>
   `;
   }

--- a/src/js/components/balance-of-power-senate/index.js
+++ b/src/js/components/balance-of-power-senate/index.js
@@ -124,10 +124,8 @@ class BalanceOfPowerSenate extends ElementBase {
         senate.netGain = topSenate.gains;
     }
 
-    //! UPDATE OR REMOVE LINK (LINK IS ONLY NEEDED FOR EMBED)
     this.innerHTML = `
     <div id="embed-bop-on-page" class="embed-bop">
-    <a class="link-container senate" href="http://apps.npr.org/election-results-live-2022/#/senate" target="_top">
       <div class="number-container">
         <div class="candidate dem">
           <div class="name">Dem. ${senate.Dem.total >= 51 ? winnerIcon : ""}</div>
@@ -151,17 +149,13 @@ class BalanceOfPowerSenate extends ElementBase {
         </div>
       </div>
 
- <div class="bar-container">
-  <div class="bar dem" style="width: ${senate.Dem.total}%">
-  </div>
-  <div class="bar other dem" style="width: ${senate.IndCaucusDem.total}%">
-  </div>
-  <div class="bar gop" style="width: ${senate.GOP.total}%">
-  </div>
-  <div class="bar other gop" style="width: ${senate.IndCaucusGOP.total}%">
-  </div>
-  <div class="middle"></div>
-</div>
+        <div class="bar-container">
+          <div class="bar dem" style="width: ${senate.Dem.total}%"></div>
+          <div class="bar other dem" style="width: ${senate.IndCaucusDem.total}%"></div>
+          <div class="bar gop" style="width: ${senate.GOP.total}%"></div>
+          <div class="bar other gop" style="width: ${senate.IndCaucusGOP.total}%"></div>
+          <div class="middle"></div>
+        </div>
       </div>
 
       <div class="bop-footer">
@@ -175,7 +169,6 @@ class BalanceOfPowerSenate extends ElementBase {
       </div>
 
       ${ footnote }
-    </a>
   </div>
   `;
   }

--- a/src/js/components/cartogram/index.js
+++ b/src/js/components/cartogram/index.js
@@ -203,10 +203,10 @@ class Cartogram extends ElementBase {
     if (!group) return;
     const state = group.getAttribute("data-postal");
     if (state) {
-      window.location.href = `#/states/${state}/P`;
       track("clicked-cartogram", state);
+      var linkTarget = document.head.querySelector("base").target || "_blank";
       var stateFull = statePostalToFull(state);
-      window.location.href = `${ classify(stateFull) }.html?section=P`;
+      window.open(`${ classify(stateFull) }.html?section=P`, linkTarget);
     }
   }
 

--- a/src/js/components/electoralBubbles/index.js
+++ b/src/js/components/electoralBubbles/index.js
@@ -248,15 +248,11 @@ class ElectoralBubbles extends ElementBase {
     this.render();
   }
 
-  goToState(state) {
-    track("clicked-bubble", state);
-    var stateFull = statePostalToFull(state);
-    window.location.href = `${ classify(stateFull) }.html?section=P`;
-  }
-
       goToState(state) {
         track("clicked-bubble", state);
-        window.location.href = `#/states/${state}/P`;
+        var linkTarget = document.head.querySelector("base").target || "_blank";
+        var stateFull = statePostalToFull(state);
+        window.open(`./${ classify(stateFull) }.html?section=P`, linkTarget);
       }
     
       onMove(e) {

--- a/src/js/components/nationalMap/index.js
+++ b/src/js/components/nationalMap/index.js
@@ -172,8 +172,9 @@ class NationalMap extends ElementBase {
     const state = e.target.getAttribute("data-postal");
     if (state) {
       track("clicked-map", state);
+      var linkTarget = document.head.querySelector("base").target || "_blank";
       var stateFull = statePostalToFull(state);
-      window.location.href = `${ classify(stateFull) }.html?section=P`;
+      window.open(`./${ classify(stateFull) }.html?section=P`, linkTarget);
     }
   }
 

--- a/src/js/components/results-board/index.js
+++ b/src/js/components/results-board/index.js
@@ -182,7 +182,7 @@ class ResultsBoard extends ElementBase {
                             return `
                                 <tr key="${r.id}" class="tr ${hasResult ? "closed" : "open"} index-${i}" role="row">
                                     <td class="state" role="cell">
-                                        <a target="_top" href="./${ classify(r.stateName) }.html?section=${r.office}">
+                                        <a href="./${ classify(r.stateName) }.html?section=${r.office}">
                                             <span class="not-small">
                                                 ${this.states[r.state].ap + seatLabel + ballotLabel}
                                             </span>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -20,16 +20,29 @@ require("./components/electoralBubbles");
 require("./components/county-map");
 require("./components/results-collection");
 
+var baseTarget = document.head.querySelector("base");
+if (baseTarget == null) {
+  baseTarget = document.createElement("base");
+  document.getElementsByTagName('head')[0].appendChild(baseTarget);
+}
+baseTarget.target = "_top";
+
 const urlParams = new URLSearchParams(window.location.search);
 
 if (urlParams.has('embedded')) {
-    const isEmbedded = urlParams.get('embedded');
+  const isEmbedded = urlParams.get('embedded');
 
-    if (isEmbedded) {
-        Sidechain.registerGuest();
-    }
+  if (isEmbedded) {
+    Sidechain.registerGuest();
+
+    document.body.classList.add("embedded");
+
+    // everything should open in a new window from embeds
+    baseTarget.target = "_blank";
+  }
 }
 
+// close disclaimer alert box
 if (document.querySelector("#close-disclaimer")) {
   document
     .querySelector("#close-disclaimer")

--- a/src/presidentMaps.html
+++ b/src/presidentMaps.html
@@ -2,47 +2,43 @@
 <html lang="en-US">
 
 <head>
-    <%= t.include("partials/_head.html", grunt.data.json) %>
-        <link rel="stylesheet" type="text/css" href="style.css">
+  <%= t.include("partials/_head.html", grunt.data.json) %>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <base target="_blank">
 </head>
 
 <body>
+  <main class="app constrained">
     <div>
+      <div id="president-wrapper"></div>
     </div>
+  </main>
 
-    <main class="app constrained">
-        <div>
-            <div id="president-wrapper">
-            </div>
-        </div>
+  <script>
+    window.PROJECT_ANALYTICS = <%= JSON.stringify(json.project.analytics || {}) %>;
+  </script>
+  <script>
+    function buildComponents() {
+      const params = new URLSearchParams(window.location.search);
+      const options = params.get('options')?.split(',') || []; // Get options from URL
 
+      // Build data attributes string
+      const dataAttrs = options.map(opt => `data-${opt}`).join(' ');
 
-    </main>
-    <script>
-        window.PROJECT_ANALYTICS = <%= JSON.stringify(json.project.analytics || {}) %>;
-    </script>
-    <script>
-        function buildComponents() {
-            const params = new URLSearchParams(window.location.search);
-            const options = params.get('options')?.split(',') || []; // Get options from URL
+      // Create component with data attributes if any are selected
+      const component = `<board-president${dataAttrs ? ' ' + dataAttrs : ''} data-hide-results></board-president>`;
 
-            // Build data attributes string
-            const dataAttrs = options.map(opt => `data-${opt}`).join(' ');
+      const container = document.getElementById('president-wrapper');
+      if (container) {
+          container.innerHTML = component;
+      }
+    }
 
-            // Create component with data attributes if any are selected
-            const component = `<board-president${dataAttrs ? ' ' + dataAttrs : ''} data-hide-results></board-president>`;
-
-            const container = document.getElementById('president-wrapper');
-            if (container) {
-                container.innerHTML = component;
-            }
-        }
-
-        // Run when page loads
-        window.addEventListener('DOMContentLoaded', buildComponents);
-    </script>
-    <script src="app.js" async></script>
-    <%= t.include("partials/_analytics.html") %>
+    // Run when page loads
+    window.addEventListener('DOMContentLoaded', buildComponents);
+  </script>
+  <script src="app.js" async></script>
+  <%= t.include("partials/_analytics.html") %>
 </body>
 
 </html>

--- a/src/race-embed.html
+++ b/src/race-embed.html
@@ -16,6 +16,7 @@ var metadata = {
   <head>
     <%= t.include("partials/_head.html", metadata) %>
     <link rel="stylesheet" type="text/css" href="race-embed.css">
+    <base target="_blank" />
   </head>
   <body>
     <main class="app constrained">


### PR DESCRIPTION
Highlights:

* Set a `<base target />` for each page via `main.js`. The default is `_top`. For embeds, it's `_blank`.
* Set the boards and the presidential graphic components to open links based on the `<base target />` on the page
* Remove the link wrapping the BOPs on the house and senate boards