### PR TITLE
saved ~quarter-to-half a second

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data/*.sheet.json
 data/*.docs.txt
 src/assets/synced
 stage-elections24-general.json
+.env

--- a/tasks/lib/normalizeResults.js
+++ b/tasks/lib/normalizeResults.js
@@ -53,7 +53,7 @@ const translation = {
     incumbent: "incumbent",
     rankedChoiceVotes: "rankedChoiceVotes",
     eliminated: "eliminated",
-    caucusWith: "caucusWith"
+    caucusWith: "caucusWith",
   },
   metadata: {
     previousParty: "party",
@@ -313,7 +313,17 @@ module.exports = function (resultArray, overrides = {}) {
         }
 
         unitMeta.candidates = ballot;
-        output.push(unitMeta);
+
+        if (
+          !(
+            (unitMeta.state == "DC" || unitMeta.state == "AK") &&
+            unitMeta.level == "county"
+          )
+        ) {
+          output.push(unitMeta);
+        }
+
+        // output.push(unitMeta);
       }
     }
   }


### PR DESCRIPTION
I used `performance.now()` in the `elex.js` file to see how long the function took to run. 

Instead of looping over the results three times, I looped over them once and added them to the respective arrays. I did this at two places, saving us some time. And one another place, slightly different but with the same concept.

I understand if we want to avoid merging this close to the election. 

The time it takes to run is different every time, so it is hard to say precisely how many ms it saves, but I ran it a couple of times, and it saves us between a quarter to half a second. (It even showed 1 sec at one point)


