### PR TITLE
fixing two small typos that cause breaks

### DIFF
--- a/src/js/components/board-senate/index.js
+++ b/src/js/components/board-senate/index.js
@@ -34,13 +34,12 @@ class BoardSenate extends ElementBase {
     connectedCallback() {
         this.loadData();
         this.illuminate();
-        gopher.watch(this.getAttribute("./data/senate.json"), this.loadData);
+        gopher.watch("./data/senate.json", this.loadData);
     }
 
     disconnectedCallback() {
-        gopher.unwatch(this.getAttribute("./data/senate.json"), this.loadData);
+        gopher.unwatch("./data/senate.json",  this.loadData);
     }
-
 
     async loadData() {
         try {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -16,6 +16,9 @@ require("./components/board-governor");
 require("./components/board-house");
 require("./components/county-map");
 require("./components/results-collection");
+require("./components/nationalMap");
+require("./components/cartogram");
+require("./components/electoralBubbles");
 
 var baseTarget = document.head.querySelector("base");
 if (baseTarget == null) {


### PR DESCRIPTION
two small typos that were merged into main that cause breakinb changes

typo 1: senate board had the wrong file name for its gopher watching

typo 2: main.js excluded the js file for the electoral bubbles component, causing it to not show 

Both are fixed with this patch 