### PR TITLE
hide state page embed header in CSS; closes #291

### DIFF
--- a/src/_state.html
+++ b/src/_state.html
@@ -58,7 +58,7 @@
     <link rel="stylesheet" type="text/css" href="state.css">
     <link rel="stylesheet" type="text/css" href="county.css">
   </head>
-  <body data-section="key-races">
+  <body data-section="key-races" data-header="show">
     <%= t.include("partials/_navbar.html") %>
     <%= t.include("partials/_ad.html", {id: "ad-centerstage"}) %>
     <%= t.include("partials/_about-box.html") %>

--- a/src/css/state.less
+++ b/src/css/state.less
@@ -17,6 +17,9 @@
 
 header {
 	margin-top: 30px;
+	body[data-header="hide"] & {
+		display: none;
+	}
 }
 
 header, main {

--- a/src/js/components/state-page-results/index.js
+++ b/src/js/components/state-page-results/index.js
@@ -220,16 +220,6 @@ class StatePageResults extends ElementBase {
     });
 
     this.innerHTML = template;
-    //show section from URL param
-    const urlParams = new URLSearchParams(window.location.search);
-    var selectedSection = urlParams.get("section");
-    var sectionName = Object.keys(offices).find(
-      (key) => offices[key] === selectedSection
-    );
-    var showSection = document.querySelector(
-      "section#" + sectionName + "-section"
-    );
-    showSection.classList.add("shown");
   }
 }
 

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -53,8 +53,7 @@ window.onload = function() { oldOnload();
     }
     var showHeader = urlParams.get("showHeader");
     if (showHeader == "false") {
-      const headerElement = document.querySelector("header");
-      headerElement.style.display = "none";
+      document.querySelector("body").dataset.header = "hide";
     }
   }
 


### PR DESCRIPTION
Also deleted section showing & hiding functionality from state-page-results/index.js. I don't believe it was doing anything.