### PR TITLE
proposed fix for issue #303

### DIFF
--- a/src/js/components/results-board/results-board.less
+++ b/src/js/components/results-board/results-board.less
@@ -171,7 +171,7 @@ table.results {
 
       .x-small { display: none; }
 
-      @media @mobile {
+      @mobile: ~"(max-width: 500px)" {
         flex: 0 0 39px;
         .x-small { display: inline; }
         .not-small { display: none; }


### PR DESCRIPTION
There's some clashing css being compiled and I'm not sure how it's not a bigger issue. Here's the issue...

`results-board.less` seems to be compiled two times, once that ends up in `house.css` and once that ends up in `style.css`. Here is the section of code in `results-board.less` in question:

```
    .state-hed {
      flex: 0 0 60px;

      .x-small { display: none; }

      @media @mobile {
        flex: 0 0 39px;
        .x-small { display: inline; }
        .not-small { display: none; }
      }
    }
```

The issue here is that `@media @mobile` is defined in two different ways in our code base. 

In `values.less` it is:
```
@mobile: ~"(max-width: 500px)";
```

In `navbar.less` it is:
```
@mobile: ~"(max-width: 650px)";
```

So on the baked out html page for house or senate results we have BOTH of these sections of code:
```
@media (max-width: 500px) {
  table.results tr .state,
  table.results tr .state-hed {
    flex: 0 0 39px;
  }
  table.results tr .state .x-small,
  table.results tr .state-hed .x-small {
    display: inline;
  }
  table.results tr .state .not-small,
  table.results tr .state-hed .not-small {
    display: none;
  }
}
```
and 
```
@media (max-width: 650px) {
  table.results tr .state,
  table.results tr .state-hed {
    flex: 0 0 39px;
  }
  table.results tr .state .x-small,
  table.results tr .state-hed .x-small {
    display: inline;
  }
  table.results tr .state .not-small,
  table.results tr .state-hed .not-small {
    display: none;
  }
}
```

Thus, the precedence cascades to the second media query (650px). I'm not sure why we need both of these anyway, and in this case, it is causing an issue. For some reason I haven't figured out, when the breakpoint is 650, `x-small` isn't correctly staying on past 500px. That's causing the blackout between 500 and 650 (x-small turning off due to one media query, not-small not turning ON till another) 

My solution is to hardcode 500px into that particular media query. I think this should work for the time being but a more holistic solution to the duplicate css may be wise in the long run. 