### PR TITLE
removed a commented import

### DIFF
--- a/src/css/race-embed.less
+++ b/src/css/race-embed.less
@@ -1,4 +1,3 @@
-// @import "values";
 @import "base";
 @import "../js/components/results-table/results-table";
 @import "../js/components/test-banner/test-banner";


### PR DESCRIPTION
I pulled latest from main, ran `grunt` and got an error about an import. Figured out it was coming from the `race-embed.less` file. It was an import but it was commented out, so I don't know why it was failing, but I removed the comment, it worked. 